### PR TITLE
fix: support pass bazel build arguments.

### DIFF
--- a/README.org
+++ b/README.org
@@ -159,12 +159,12 @@ exit 0
    #+BEGIN_SRC sh :tangle create_compile_commands.sh :shebang #!/bin/sh :tangle-mode (identity #o555) :exports both
 set -e
 
-if [ "$#" -ne 1 ]; then
-    echo "Usage: $(basename $0) BAZEL_TARGET"
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $(basename $0) BAZEL_BUILD_ARGUMENTS"
     exit 1
 fi
 
-bazel build --experimental_action_listener=//tools/actions:generate_compile_commands_listener $1
+bazel build --experimental_action_listener=//tools/actions:generate_compile_commands_listener $*
 python3 ./tools/actions/generate_compile_commands_json.py
 exit 0
    #+END_SRC

--- a/create_compile_commands.sh
+++ b/create_compile_commands.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -e
 
-if [ "$#" -ne 1 ]; then
-    echo "Usage: $(basename $0) BAZEL_TARGET"
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $(basename $0) BAZEL_BUILD_ARGUMENTS"
     exit 1
 fi
 
-bazel build --experimental_action_listener=//tools/actions:generate_compile_commands_listener $1
+bazel build --experimental_action_listener=//tools/actions:generate_compile_commands_listener $*
 python3 ./tools/actions/generate_compile_commands_json.py
 exit 0


### PR DESCRIPTION
When build envoy, i need pass extra build arguments to bazel, such as:

     ~/Opensource/Bazel_and_CompileCommands/create_compile_commands.sh \
       --action_env CC=/usr/bin/gcc-5 \
       --action_env CPP=/usr/bin/cpp-5 \
       --action_env CXX=/usr/bin/c++-5 \
       --verbose_failures //source/exe:envoy-static